### PR TITLE
Add Open Graph and Twitter meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Kouvosto3D – Räätälöity 3D-tulostus</title>
   <meta name="description" content="Räätälöity 3D-tulostus PLA- ja PETG-materiaaleilla. Bambu A1 256×256×256 mm." />
+  <meta property="og:title" content="Kouvosto3D – Räätälöity 3D-tulostus" />
+  <meta property="og:description" content="Räätälöity 3D-tulostus PLA- ja PETG-materiaaleilla. Bambu A1 256×256×256 mm." />
+  <meta property="og:image" content="https://i.imgur.com/ds0WVfb.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Kouvosto3D – Räätälöity 3D-tulostus" />
+  <meta name="twitter:description" content="Räätälöity 3D-tulostus PLA- ja PETG-materiaaleilla. Bambu A1 256×256×256 mm." />
+  <meta name="twitter:image" content="https://i.imgur.com/ds0WVfb.png" />
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="min-h-screen" style="background:#fff; color:#1f2937">


### PR DESCRIPTION
## Summary
- add Open Graph meta tags for title, description and image
- include matching Twitter card metadata

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895c95c2f488320b804754a05c57d65