### PR TITLE
Describe gallery images in alt text

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,28 +166,28 @@
         <p class="mt-2 text-gray-600 leading-relaxed">Esimerkkejä tulosteista (korvaa omilla kuvillasi).</p>
         <div class="mt-6 grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4">
           <figure class="rounded-xl overflow-hidden border bg-white hover:shadow-sm transition-shadow" style="border-color:#F5CBCB">
-            <img src="https://picsum.photos/seed/kouvosto1/800/800" alt="Tuloste 1" class="w-full h-full object-cover aspect-square" />
+            <img src="https://picsum.photos/seed/kouvosto1/800/800" alt="Lähikuva taittuvista viivaimista" class="w-full h-full object-cover aspect-square" />
           </figure>
           <figure class="rounded-xl overflow-hidden border bg-white hover:shadow-sm transition-shadow" style="border-color:#F5CBCB">
-            <img src="https://picsum.photos/seed/kouvosto2/800/800" alt="Tuloste 2" class="w-full h-full object-cover aspect-square" />
+            <img src="https://picsum.photos/seed/kouvosto2/800/800" alt="Ruskeat kiviset kukkulat valkeaa taivasta vasten" class="w-full h-full object-cover aspect-square" />
           </figure>
           <figure class="rounded-xl overflow-hidden border bg-white hover:shadow-sm transition-shadow" style="border-color:#F5CBCB">
-            <img src="https://picsum.photos/seed/kouvosto3/800/800" alt="Tuloste 3" class="w-full h-full object-cover aspect-square" />
+            <img src="https://picsum.photos/seed/kouvosto3/800/800" alt="Harmaat kukkulat vuorijonon vieressä päivällä" class="w-full h-full object-cover aspect-square" />
           </figure>
           <figure class="rounded-xl overflow-hidden border bg-white hover:shadow-sm transition-shadow" style="border-color:#F5CBCB">
-            <img src="https://picsum.photos/seed/kouvosto4/800/800" alt="Tuloste 4" class="w-full h-full object-cover aspect-square" />
+            <img src="https://picsum.photos/seed/kouvosto4/800/800" alt="Valkoinen puinen hengenpelastajan torni rannalla auringonlaskun aikaan" class="w-full h-full object-cover aspect-square" />
           </figure>
           <figure class="rounded-xl overflow-hidden border bg-white hover:shadow-sm transition-shadow" style="border-color:#F5CBCB">
-            <img src="https://picsum.photos/seed/kouvosto5/800/800" alt="Tuloste 5" class="w-full h-full object-cover aspect-square" />
+            <img src="https://picsum.photos/seed/kouvosto5/800/800" alt="MacBook Air, musta iPhone 4 ja juomalasi pöydällä" class="w-full h-full object-cover aspect-square" />
           </figure>
           <figure class="rounded-xl overflow-hidden border bg-white hover:shadow-sm transition-shadow" style="border-color:#F5CBCB">
-            <img src="https://picsum.photos/seed/kouvosto6/800/800" alt="Tuloste 6" class="w-full h-full object-cover aspect-square" />
+            <img src="https://picsum.photos/seed/kouvosto6/800/800" alt="Henkilö seisoo merenrannalla" class="w-full h-full object-cover aspect-square" />
           </figure>
           <figure class="rounded-xl overflow-hidden border bg-white hover:shadow-sm transition-shadow" style="border-color:#F5CBCB">
-            <img src="https://picsum.photos/seed/kouvosto7/800/800" alt="Tuloste 7" class="w-full h-full object-cover aspect-square" />
+            <img src="https://picsum.photos/seed/kouvosto7/800/800" alt="Kuva korkeista kerrostaloista" class="w-full h-full object-cover aspect-square" />
           </figure>
           <figure class="rounded-xl overflow-hidden border bg-white hover:shadow-sm transition-shadow" style="border-color:#F5CBCB">
-            <img src="https://picsum.photos/seed/kouvosto8/800/800" alt="Tuloste 8" class="w-full h-full object-cover aspect-square" />
+            <img src="https://picsum.photos/seed/kouvosto8/800/800" alt="Harmaasävykuva taloista vuoristomaiseman ja veden äärellä" class="w-full h-full object-cover aspect-square" />
           </figure>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Replace generic gallery image alt attributes with descriptive Finnish text.

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_6895c95f0f148320ad5d10768c8b901f