### PR TITLE
Automate sitemap lastmod update

### DIFF
--- a/.github/workflows/update-sitemap.yml
+++ b/.github/workflows/update-sitemap.yml
@@ -1,0 +1,24 @@
+name: Update sitemap
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Update lastmod
+        run: |
+          python update_sitemap_lastmod.py
+      - name: Commit changes
+        run: |
+          if [[ -n "$(git status --porcelain sitemap.xml)" ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -am "chore: update sitemap lastmod"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # kouvosto3d
 
 Generated with ChatGPT
+
+## Development
+
+- `update_sitemap_lastmod.py` updates `sitemap.xml` with the current date.
+- `.github/workflows/update-sitemap.yml` runs the script on each push to keep the sitemap fresh.

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://kouvosto3d.fi/</loc>
-    <lastmod>2025-06-24</lastmod>
+    <lastmod>2025-08-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/update_sitemap_lastmod.py
+++ b/update_sitemap_lastmod.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Update sitemap.xml <lastmod> to current UTC date."""
+from datetime import datetime
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parent
+
+def get_today() -> str:
+    """Return current date in YYYY-MM-DD format (UTC)."""
+    return datetime.utcnow().date().isoformat()
+
+
+def update_sitemap(date: str) -> None:
+    sitemap = ROOT / "sitemap.xml"
+    content = sitemap.read_text(encoding="utf-8")
+    updated = re.sub(r"<lastmod>.*?</lastmod>", f"<lastmod>{date}</lastmod>", content)
+    sitemap.write_text(updated, encoding="utf-8")
+
+
+def main() -> None:
+    date = get_today()
+    update_sitemap(date)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Replace hard-coded `<lastmod>` in `sitemap.xml` with current date.
- Add `update_sitemap_lastmod.py` script to update sitemap automatically.
- Create GitHub Action to run script on each push.
- Document sitemap automation in README.

## Testing
- `python3 update_sitemap_lastmod.py`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895c960ea008320b66511b26176c50d