### PR TITLE
Remove keywords meta tag from head

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
 
   <title>Kouvosto3D – Räätälöity 3D-tulostus</title>
   <meta name="description" content="Räätälöity FDM 3D-tulostus PLA- ja PETG-materiaaleilla. Bambu A1 256×256×256 mm." />
-  <meta name="keywords" content="3D-tulostus, FDM, PLA, PETG, Kouvola, viraali 3D print" />
   <meta name="robots" content="index, follow" />
   <meta property="og:title" content="Kouvosto3D – Räätälöity FDM 3D-tulostus" />
   <meta property="og:description" content="Räätälöity FDM 3D-tulostus PLA- ja PETG-materiaaleilla. Bambu A1 256×256×256 mm." />


### PR DESCRIPTION
## Summary
- remove outdated `meta name="keywords"` from `index.html`
- ensure other SEO meta tags remain (title, description, Open Graph, Twitter)

## Testing
- `python -m py_compile update_sitemap_lastmod.py`
- `tidy -qe index.html`


------
https://chatgpt.com/codex/tasks/task_e_6895d2c6731883209f96ef7b082ff96f