### PR TITLE
fix mobile footer overlay and improve material info

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,7 +256,7 @@
   </main>
 
   <!-- Footer -->
-  <footer class="border-t backdrop-blur" style="background:rgba(255,255,255,.6); border-color:#9ECAD6">
+  <footer class="border-t backdrop-blur mb-24 md:mb-0" style="background:rgba(255,255,255,.6); border-color:#9ECAD6">
     <div class="mx-auto max-w-5xl px-4 py-8 text-sm text-gray-600 grid gap-2">
       <div>© <span id="year"></span> kouvosto3d</div>
       <div class="flex flex-wrap items-center gap-4">
@@ -290,19 +290,19 @@
     <div class="relative max-w-xs w-full bg-white rounded-lg shadow-lg p-4 text-gray-700">
       <button id="plaClose" class="absolute top-1 right-2 text-2xl leading-none text-gray-500 hover:text-gray-700" aria-label="Sulje">&times;</button>
       <h3 class="text-lg font-semibold mb-2">PLA</h3>
-      <p class="text-sm leading-relaxed">Kevyt ja helppo materiaali. Sopii prototyyppeihin, koristeisiin ja pieniin arkiesineisiin.</p>
+      <p class="text-sm leading-relaxed">Kevyt ja helppo materiaali. Sopii prototyyppeihin, koristeisiin ja pieniin arkiesineisiin. PLA on biohajoava vaihtoehto, mutta se ei kestä korkeaa lämpöä tai kovaa rasitusta.</p>
     </div>
   </div>
   <div id="petgModal" class="material-modal fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 hidden">
     <div class="relative max-w-xs w-full bg-white rounded-lg shadow-lg p-4 text-gray-700">
       <button id="petgClose" class="absolute top-1 right-2 text-2xl leading-none text-gray-500 hover:text-gray-700" aria-label="Sulje">&times;</button>
       <h3 class="text-lg font-semibold mb-2">PETG</h3>
-      <p class="text-sm leading-relaxed">Kestävä ja joustava materiaali. Hyvä varaosiin, arjen käyttöesineisiin ja ulkokäyttöön.</p>
+      <p class="text-sm leading-relaxed">Kestävä ja joustava materiaali. Hyvä varaosiin, arjen käyttöesineisiin ja ulkokäyttöön. PETG on PLA:ta kalliimpi, mutta se kestää paremmin lämpöä, UV-säteilyä ja mekaanista rasitusta, joten se on erinomainen valinta useimpiin tarpeisiin.</p>
     </div>
   </div>
 
   <!-- Sticky mobile CTA -->
-    <div class="fixed bottom-0 left-0 right-0 md:hidden border-t backdrop-blur px-3 py-3" style="background:rgba(255,255,255,.96); border-color:#F5CBCB">
+    <div class="fixed bottom-0 left-0 right-0 md:hidden border-t backdrop-blur px-3 py-3" style="background:rgba(255,255,255,.6); border-color:#9ECAD6">
       <div class="mx-auto max-w-5xl flex items-center gap-2">
         <a href="#quote" class="flex-1 text-center px-4 py-2 rounded-md font-medium text-white" style="background:#748DAE">Pyydä tarjous</a>
         <a href="#gallery" class="px-4 py-2 rounded-md font-medium border" style="border-color:#748DAE; color:#748DAE">Galleria</a>


### PR DESCRIPTION
## Summary
- prevent sticky CTA from hiding footer content on mobile
- match mobile CTA styling with frosted header look
- expand PLA and PETG material descriptions

## Testing
- `python -m py_compile update_sitemap_lastmod.py`


------
https://chatgpt.com/codex/tasks/task_e_6895dc52e0588320876c9307fc487900